### PR TITLE
Add pytz to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='tap-purecloud',
           'backoff==1.3.2',
           'requests==2.25.1',
           'python-dateutil==2.6.0',
+          'pytz==2021.3',
           'PureCloudPlatformClientV2==111.0.0',
           'websockets==5.0.1'
       ],


### PR DESCRIPTION
Firstly thanks so much for maintaining this connector!

I'm currently trying to get it working with [Meltano](https://hub.meltano.com/taps/purecloud). After I install it and run `meltano invoke tap-purecloud --help` to check if it's installed correctly I get an error about pytz not being installed in the venv Meltano has created for the tap.

The issue is fixable manually by activating the venv for tap-purecloud and doing `pip3 install pytz`, but having it in the setup.py avoids the need for this and makes for an easier install. 

Have confirmed locally that you no longer get the error about pytz if you install from this branch.

